### PR TITLE
PLF-90 Allow logging print stack like debug.PrintStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Add JSONFormatter.
 -   Change extra, message, and log design.
+-   It is possible to log stack trace.
 
 # v0.0.1 (Sep 02, 2022)
 

--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,8 @@ package xylog
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
+	"strings"
 
 	"github.com/xybor-x/xycond"
 	"github.com/xybor-x/xylock"
@@ -221,7 +223,7 @@ func (lg *Logger) Logf(level int, s string, a ...any) {
 	}
 }
 
-// Event creates an eventLogger which logs key-value pairs.
+// Event creates an EventLogger which logs key-value pairs.
 func (lg *Logger) Event(e string) *EventLogger {
 	var elogger = &EventLogger{
 		lg:     lg,
@@ -230,6 +232,16 @@ func (lg *Logger) Event(e string) *EventLogger {
 	}
 	elogger.fields = append(elogger.fields, lg.persistentFields...)
 	return elogger.Field("event", e)
+}
+
+// Stack logs the stack trace.
+func (lg *Logger) Stack(level int) {
+	var s = string(debug.Stack())
+	var lines = strings.Split(s, "\n")
+
+	for i := range lines {
+		lg.log(level, lines[i])
+	}
 }
 
 // log is a low-level logging method which creates a LogRecord and then calls

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,16 +1,17 @@
 package xylog_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/xybor-x/xycond"
 	"github.com/xybor-x/xylog"
 )
 
-func checkLogOutput(t *testing.T, f func(), msg string, lv, loggerLv int) {
+func checkLogOutput(t *testing.T, f func(), msg string, lv, loggerlv int) {
 	capturedOutput = ""
 	f()
-	if lv < loggerLv {
+	if lv < loggerlv {
 		xycond.ExpectEmpty(capturedOutput).Test(t)
 	} else {
 		xycond.ExpectEqual(capturedOutput, msg).Test(t)
@@ -184,6 +185,18 @@ func TestLoggerLogValidCustomLevel(t *testing.T) {
 		checkLogOutput(t, func() { logger.Logf(validCustomLevels[i], "foo") },
 			"foo", validCustomLevels[i], loggerLevel)
 	}
+}
+
+func TestLoggerStack(t *testing.T) {
+	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+	handler.SetFormatter(xylog.NewTextFormatter("%(levelname)s %(message)s"))
+	var logger = xylog.GetLogger("example.Stack")
+	logger.SetLevel(xylog.DEBUG)
+	logger.AddHandler(handler)
+
+	xycond.ExpectNotPanic(func() {
+		logger.Stack(xylog.DEBUG)
+	}).Test(t)
 }
 
 func TestLoggerFilter(t *testing.T) {

--- a/root.go
+++ b/root.go
@@ -1,106 +1,118 @@
 package xylog
 
-// AddHandler adds a new handler to root logger.
+// AddHandler adds a new handler to the root logger.
 func AddHandler(h *Handler) {
 	rootLogger.AddHandler(h)
 }
 
-// RemoveHandler removes an existed handler from root logger.
+// RemoveHandler removes an existed handler from the root logger.
 func RemoveHandler(h *Handler) {
 	rootLogger.RemoveHandler(h)
 }
 
-// AddFilter adds a specified filter to root logger.
+// AddFilter adds a specified filter to the root logger.
 func AddFilter(f Filter) {
 	rootLogger.AddFilter(f)
 }
 
-// RemoveFilter removes an existed filter from root logger.
+// RemoveFilter removes an existed filter from the root logger.
 func RemoveFilter(f Filter) {
 	rootLogger.RemoveFilter(f)
 }
 
-// SetLevel sets the new logging level for root logger.
+// SetLevel sets the new logging level for the root logger.
 func SetLevel(level int) {
 	rootLogger.SetLevel(level)
 }
 
-// Debug logs default formatting objects with DEBUG level by root logger.
+// Debug logs default formatting objects with DEBUG level by the root logger.
 func Debug(a ...any) {
 	rootLogger.Debug(a...)
 }
 
-// Debugf logs a formatting message with DEBUG level by root logger.
+// Debugf logs a formatting message with DEBUG level by the root logger.
 func Debugf(msg string, a ...any) {
 	rootLogger.Debugf(msg, a...)
 }
 
-// Info logs default formatting objects with INFO level by root logger.
+// Info logs default formatting objects with INFO level by the root logger.
 func Info(a ...any) {
 	rootLogger.Info(a...)
 }
 
-// Infof logs a formatting message with INFO level by root logger.
+// Infof logs a formatting message with INFO level by the root logger.
 func Infof(msg string, a ...any) {
 	rootLogger.Infof(msg, a...)
 }
 
-// Warn logs default formatting objects with WARN level by root logger.
+// Warn logs default formatting objects with WARN level by the root logger.
 func Warn(a ...any) {
 	rootLogger.Warn(a...)
 }
 
-// Warnf logs a formatting message with WARN level by root logger.
+// Warnf logs a formatting message with WARN level by the root logger.
 func Warnf(msg string, a ...any) {
 	rootLogger.Warnf(msg, a...)
 }
 
-// Warning logs default formatting objects with WARNING level by root logger.
+// Warning logs default formatting objects with WARNING level by the root
+// logger.
 func Warning(a ...any) {
 	rootLogger.Warning(a...)
 }
 
-// Warningf logs a formatting message with WARNING level by root logger.
+// Warningf logs a formatting message with WARNING level by the root logger.
 func Warningf(msg string, a ...any) {
 	rootLogger.Warningf(msg, a...)
 }
 
-// Error logs default formatting objects with ERROR level by root logger.
+// Error logs default formatting objects with ERROR level by the root logger.
 func Error(a ...any) {
 	rootLogger.Error(a...)
 }
 
-// Errorf logs a formatting message with ERROR level by root logger.
+// Errorf logs a formatting message with ERROR level by the root logger.
 func Errorf(msg string, a ...any) {
 	rootLogger.Errorf(msg, a...)
 }
 
-// Fatal logs default formatting objects with FATAL level by root logger.
+// Fatal logs default formatting objects with FATAL level by the root logger.
 func Fatal(a ...any) {
 	rootLogger.Fatal(a...)
 }
 
-// Fatalf logs a formatting message with FATAL level by root logger.
+// Fatalf logs a formatting message with FATAL level by the root logger.
 func Fatalf(msg string, a ...any) {
 	rootLogger.Fatalf(msg, a...)
 }
 
-// Critical logs default formatting objects with CRITICAL level by root logger.
+// Critical logs default formatting objects with CRITICAL level by the root
+// logger.
 func Critical(a ...any) {
 	rootLogger.Critical(a...)
 }
 
-// Criticalf logs a formatting message with DEBUG level by root logger.
+// Criticalf logs a formatting message with DEBUG level by the root logger.
 func Criticalf(msg string, a ...any) {
 	rootLogger.Criticalf(msg, a...)
 }
 
-// Log logs default formatting objects with a custom level by root logger.
+// Log logs default formatting objects with a custom level by the root logger.
 func Log(level int, a ...any) {
 	rootLogger.Log(level, a...)
 }
 
-// Logf logs a formatting message with a custom level by root logger.
+// Logf logs a formatting message with a custom level by the root logger.
 func Logf(level int, msg string, a ...any) {
 	rootLogger.Logf(level, msg, a...)
+}
+
+// Event creates an EventLogger by the root logger, which logs key-value pairs.
+func Event(s string) *EventLogger {
+	return rootLogger.Event(s)
+}
+
+// Stack logs the stack trace by the root logger.
+func Stack(level int) {
+	rootLogger.Stack(level)
 }

--- a/root_test.go
+++ b/root_test.go
@@ -108,3 +108,17 @@ func TestRootLogMethods(t *testing.T) {
 		}
 	})
 }
+
+func TestRootLoggerEvent(t *testing.T) {
+	testRootLogger(t, func(loggerLevel int) {
+		checkLogOutput(t, func() {
+			xylog.Event("foo").Field("bar", "buzz").Info()
+		}, "event=foo bar=buzz", xylog.INFO, xylog.INFO)
+	})
+}
+
+func TestRootLoggerStack(t *testing.T) {
+	xycond.ExpectNotPanic(func() {
+		xylog.Stack(xylog.ERROR)
+	}).Test(t)
+}


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-90

#### Description

-   Log with debug.PrintStack looks like an unhandled panic.
-   PrintStack should be added with logging format to differentiate from unhandled panic.

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
