### PR TITLE
PLF-114 Create StructureFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Developing
 
--   Add JSONFormatter.
+-   Add JSONFormatter and StructureFormatter.
 -   Change extra, message, and log design.
 -   It is possible to log stack trace.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ string to format the message.
 
 `JSONFormatter` allows to create a logging message of JSON format.
 
+`StructureFormatter` allows to create a logging message with format of
+`key=value`.
+
 | MACRO             | DESCRIPTION                                                                                                                                      |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `asctime`         | Textual time when the LogRecord was created.                                                                                                     |
@@ -163,6 +166,8 @@ CPU: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 
 # Example
 
+See more examples [here](./example_test.go).
+
 ## Simple usage
 
 ```golang
@@ -192,20 +197,20 @@ logger.SetLevel(xylog.DEBUG)
 logger.AddHandler(handler)
 
 for i := 0; i < 20; i++ {
-	// logger will write 80 bytes (including newlines).
-	logger.Debug("foo")
+    // logger will write 80 bytes (including newlines).
+    logger.Debug("foo")
 }
 
 if _, err := os.Stat("example.log"); err == nil {
-	fmt.Println("Created example.log")
+    fmt.Println("Created example.log")
 }
 
 if _, err := os.Stat("example.log.1"); err == nil {
-	fmt.Println("Created example.log.1")
+    fmt.Println("Created example.log.1")
 }
 
 if _, err := os.Stat("example.log.2"); err == nil {
-	fmt.Println("Created example.log.2")
+    fmt.Println("Created example.log.2")
 }
 
 // Output:
@@ -225,6 +230,25 @@ logger.Critical("foo foo")
 
 // Output:
 // CRITICAL foo foo
+```
+
+## Formatters
+
+```golang
+var formatter = xylog.NewStructureFormatter().
+    AddField("module", "name").
+    AddField("level", "levelname").
+    AddField("", "message")
+var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+handler.SetFormatter(formatter)
+
+var logger = xylog.GetLogger("example.StructureFormatter")
+logger.AddHandler(handler)
+logger.SetLevel(xylog.DEBUG)
+logger.Event("create").Field("employee", "david").Debug()
+
+// Output:
+// module=example.StructureFormatter level=DEBUG event=create employee=david
 ```
 
 ## Event Logger

--- a/example_test.go
+++ b/example_test.go
@@ -102,20 +102,46 @@ func ExampleEventLogger() {
 }
 
 func ExampleJSONFormatter() {
-	var formatter = xylog.NewJSONFormatter().
+	var formatter1 = xylog.NewJSONFormatter().
+		AddField("module", "name").
+		AddField("level", "levelname").
+		AddField("", "message")
+	var handler1 = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+	handler1.SetFormatter(formatter1)
+
+	var formatter2 = xylog.NewJSONFormatter().
 		AddField("module", "name").
 		AddField("level", "levelname").
 		AddField("message", "message")
-	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
-	handler.SetFormatter(formatter)
+	var handler2 = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+	handler2.SetFormatter(formatter2)
 
 	var logger = xylog.GetLogger("example.JSONFormatter")
-	logger.AddHandler(handler)
+	logger.AddHandler(handler1)
+	logger.AddHandler(handler2)
 	logger.SetLevel(xylog.DEBUG)
 	logger.Event("create").Field("product", 1235).JSON().Debug()
 
 	// Output:
+	// {"event":"create","level":"DEBUG","module":"example.JSONFormatter","product":1235}
 	// {"level":"DEBUG","message":{"event":"create","product":1235},"module":"example.JSONFormatter"}
+}
+
+func ExampleStructureFormatter() {
+	var formatter = xylog.NewStructureFormatter().
+		AddField("module", "name").
+		AddField("level", "levelname").
+		AddField("", "message")
+	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+	handler.SetFormatter(formatter)
+
+	var logger = xylog.GetLogger("example.StructureFormatter")
+	logger.AddHandler(handler)
+	logger.SetLevel(xylog.DEBUG)
+	logger.Event("create").Field("employee", "david").Debug()
+
+	// Output:
+	// module=example.StructureFormatter level=DEBUG event=create employee=david
 }
 
 func ExampleNewSizeRotatingFileEmitter() {

--- a/formatter.go
+++ b/formatter.go
@@ -25,9 +25,9 @@ type TextFormatter struct {
 	names  []string
 }
 
-// NewTextFormatter creates a textFormatter which uses LogRecord attributes to
-// contribute logging string, e.g. %(message)s or %(levelno)d. See LogRecord for
-// more details.
+// NewTextFormatter creates a textFormatter which uses LogRecord macros and
+// format string to contribute logging string, e.g. %(message)s or %(levelno)d.
+// See LogRecord for more details.
 func NewTextFormatter(s string) TextFormatter {
 	var tf = TextFormatter{}
 	var i, n = 0, len(s)
@@ -85,8 +85,7 @@ func (tf TextFormatter) Format(record LogRecord) (string, error) {
 	return fmt.Sprintf(tf.fmtstr, attrs...), nil
 }
 
-// JSONFormatter allows logging message to be parsed as json format. It uses the
-// same macros as other Formatter.
+// JSONFormatter allows logging message to be parsed as json format.
 type JSONFormatter struct {
 	fields []field
 }
@@ -96,27 +95,88 @@ func NewJSONFormatter() *JSONFormatter {
 	return &JSONFormatter{fields: make([]field, 0, 5)}
 }
 
-// AddField adds the macro to logging message under key name. It returns itself.
+// AddField adds the macro value to the logging message under a name. It returns
+// itself. For {message} macro and JSON event logger, you could leave the name
+// as empty if you want to add all fields of message into the outer object
+// directly.
 func (js *JSONFormatter) AddField(name, macro string) *JSONFormatter {
 	js.fields = append(js.fields, field{key: name, value: macro})
 	return js
 }
 
-// Format creates the logging message as the json format.
+// Format creates the logging message of JSON format.
 func (js JSONFormatter) Format(record LogRecord) (string, error) {
 	var err error
-	var attr = make(map[string]any)
+	var data = make(map[string]any)
 	for _, f := range js.fields {
-		attr[f.key], err = record.getAttributeByName(f.value.(string))
+		var attr, err = record.getAttributeByName(f.value.(string))
 		if err != nil {
 			return "", err
+		}
+
+		if mattr, ok := attr.(map[string]any); ok && f.key == "" {
+			for k, v := range mattr {
+				data[k] = v
+			}
+		} else {
+			data[f.key] = attr
 		}
 	}
 
 	var s []byte
-	s, err = json.Marshal(attr)
+	s, err = json.Marshal(data)
 	if err != nil {
 		return "", xyerror.ValueError.New(err)
 	}
 	return string(s), nil
+}
+
+// StructureFormatter formats the logging message with the form of key=value.
+type StructureFormatter struct {
+	fields []field
+}
+
+// NewStructureFormatter creates an empty StructureFormatter.
+func NewStructureFormatter() *StructureFormatter {
+	return &StructureFormatter{}
+}
+
+// AddField adds the macro to logging message under a name. It returns itself.
+// If you leave the name as empty, it will adds the macro value without the name
+// and equal character.
+func (sf *StructureFormatter) AddField(name, macro string) *StructureFormatter {
+	sf.fields = append(sf.fields, field{key: name, value: macro})
+	return sf
+}
+
+// Format creates the logging message with the form of key=value.
+func (sf StructureFormatter) Format(record LogRecord) (string, error) {
+	var msg string
+	for _, f := range sf.fields {
+		var attr, err = record.getAttributeByName(f.value.(string))
+		if err != nil {
+			return "", err
+		}
+
+		var value string
+		switch attr.(type) {
+		case map[string]any:
+			var s []byte
+			s, err = json.Marshal(attr)
+			if err != nil {
+				return "", err
+			}
+			value = string(s)
+		default:
+			value = fmt.Sprint(attr)
+		}
+
+		if f.key == "" {
+			msg = prefixMessage(msg, value)
+		} else {
+			msg = prefixMessage(msg, fmt.Sprintf("%s=%s", f.key, value))
+		}
+	}
+
+	return msg, nil
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -8,6 +8,23 @@ import (
 	"github.com/xybor-x/xylog"
 )
 
+var fullrecord = xylog.LogRecord{
+	Asctime:         "ASCTIME",
+	Created:         1,
+	FileName:        "FILENAME",
+	FuncName:        "FUNCNAME",
+	LevelName:       "LEVELNAME",
+	LevelNo:         2,
+	LineNo:          3,
+	Message:         "MESSAGE",
+	Module:          "MODULE",
+	Msecs:           4,
+	Name:            "NAME",
+	PathName:        "PATHNAME",
+	Process:         5,
+	RelativeCreated: 6,
+}
+
 func TestNewTextFormatter(t *testing.T) {
 	var f = xylog.NewTextFormatter(
 		"time=%(asctime)s %(levelno).3d %(module)s something")
@@ -32,22 +49,7 @@ func TestTextFormatter(t *testing.T) {
 			"%(levelno)d %(lineno)d %(message)s %(module)s %(msecs)d " +
 			"%(name)s %(pathname)s %(process)d %(relativeCreated)d")
 
-	var s, err = formatter.Format(xylog.LogRecord{
-		Asctime:         "ASCTIME",
-		Created:         1,
-		FileName:        "FILENAME",
-		FuncName:        "FUNCNAME",
-		LevelName:       "LEVELNAME",
-		LevelNo:         2,
-		LineNo:          3,
-		Message:         "MESSAGE",
-		Module:          "MODULE",
-		Msecs:           4,
-		Name:            "NAME",
-		PathName:        "PATHNAME",
-		Process:         5,
-		RelativeCreated: 6,
-	})
+	var s, err = formatter.Format(fullrecord)
 
 	xycond.ExpectError(err, nil).Test(t)
 	xycond.ExpectEqual(s, "ASCTIME 1 FILENAME FUNCNAME LEVELNAME 2 3 MESSAGE "+
@@ -70,26 +72,36 @@ func TestJSONFormatter(t *testing.T) {
 		AddField("process", "process").
 		AddField("relativeCreated", "relativeCreated")
 
-	var s, err = formatter.Format(xylog.LogRecord{
-		Asctime:         "ASCTIME",
-		Created:         1,
-		FileName:        "FILENAME",
-		FuncName:        "FUNCNAME",
-		LevelName:       "LEVELNAME",
-		LevelNo:         2,
-		LineNo:          3,
-		Message:         "MESSAGE",
-		Module:          "MODULE",
-		Msecs:           4,
-		Name:            "NAME",
-		PathName:        "PATHNAME",
-		Process:         5,
-		RelativeCreated: 6,
-	})
+	var s, err = formatter.Format(fullrecord)
 
 	xycond.ExpectError(err, nil).Test(t)
 	xycond.ExpectEqual(s, `{"asctime":"ASCTIME","created":1,"filename":`+
 		`"FILENAME","funcname":"FUNCNAME","levelname":"LEVELNAME","levelno":2,`+
 		`"lineno":3,"message":"MESSAGE","module":"MODULE","msecs":4,`+
 		`"pathname":"PATHNAME","process":5,"relativeCreated":6}`).Test(t)
+}
+
+func TestStructureFormatter(t *testing.T) {
+	var formatter = xylog.NewStructureFormatter().
+		AddField("asctime", "asctime").
+		AddField("created", "created").
+		AddField("filename", "filename").
+		AddField("funcname", "funcname").
+		AddField("levelname", "levelname").
+		AddField("levelno", "levelno").
+		AddField("lineno", "lineno").
+		AddField("message", "message").
+		AddField("module", "module").
+		AddField("msecs", "msecs").
+		AddField("pathname", "pathname").
+		AddField("process", "process").
+		AddField("relativeCreated", "relativeCreated")
+
+	var s, err = formatter.Format(fullrecord)
+
+	xycond.ExpectError(err, nil).Test(t)
+	xycond.ExpectEqual(s, "asctime=ASCTIME created=1 filename=FILENAME "+
+		"funcname=FUNCNAME levelname=LEVELNAME levelno=2 lineno=3 "+
+		"message=MESSAGE module=MODULE msecs=4 pathname=PATHNAME process=5 "+
+		"relativeCreated=6").Test(t)
 }


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-114

#### Description

-   StructureFormatter allows to make a logging message as the following text easier:
    ```golang
    key1=value1 key2=value2
    ```

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
