### PR TITLE
Logger Flush doesn't Flush parent emitters (#30)

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -155,10 +155,14 @@ func (lg *Logger) AddField(key string, value any) {
 
 // Flush writes unflushed buffered data to outputs.
 func (lg *Logger) Flush() {
-	for _, h := range lg.Handlers() {
-		for _, e := range h.Emitters() {
-			e.Flush()
+	var current = lg
+	for current != nil {
+		for _, h := range current.Handlers() {
+			for _, e := range h.Emitters() {
+				e.Flush()
+			}
 		}
+		current = current.parent
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -163,3 +163,19 @@ func TestLoggerFindCaller(t *testing.T) {
 		xycond.ExpectIn("funcname=func1", w.Captured).Test(t)
 	})
 }
+
+func TestLoggerFlushParent(t *testing.T) {
+	var writer = &test.MockWriter{}
+	var emitter = xylog.NewStreamEmitter(writer)
+	var handler = xylog.GetHandler("")
+	handler.AddEmitter(emitter)
+
+	var logger = xylog.GetLogger(t.Name())
+	logger.AddHandler(handler)
+
+	var childLogger = xylog.GetLogger(t.Name() + ".child")
+	childLogger.Error("foo")
+	childLogger.Flush()
+
+	xycond.ExpectIn("foo", writer.Captured).Test(t)
+}


### PR DESCRIPTION
#### Issue

-   Fix #30.

#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Checked README.md.
-   [x] Checked CHANGELOG.md
-   [x] Checked comments.
